### PR TITLE
chore: change cy-runner command

### DIFF
--- a/.github/workflows/quality-engineering.yml
+++ b/.github/workflows/quality-engineering.yml
@@ -742,7 +742,8 @@ jobs:
           needs.safeCheck.outputs.substantialChanges == 'true'
           || github.event_name == 'schedule'
           || github.event_name == 'workflow_dispatch'
-        run: yarn cy-r
+        run: node cy-runner
+        working-directory: cy-runner
         env:
           VTEX_QE: ${{ secrets.cypressJSON }}
           NODE_NO_WARNINGS: 1


### PR DESCRIPTION
Change way Cy-Runner is called to not rely on `package.json`