### PR TITLE
ENGINEERS-895 Disable shallow clone for SonarCloud

### DIFF
--- a/.github/workflows/quality-engineering.yml
+++ b/.github/workflows/quality-engineering.yml
@@ -466,6 +466,8 @@ jobs:
       - name: "Trusted checkout"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         if: github.event.pull_request.head.repo.fork == false
+        with:
+          fetch-depth: 0
 
       - name: "Untrusted checkout"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
@@ -714,6 +716,8 @@ jobs:
       - name: "Trusted checkout"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         if: github.event.pull_request.head.repo.fork == false
+        with:
+          fetch-depth: 0
 
       - name: "Untrusted checkout"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0


### PR DESCRIPTION
Shallow clones should be disabled for a better relevancy of analysis.