### PR TITLE
fix: upgrade jdk from 11 to 17 to fix sonarcloud scans

### DIFF
--- a/.github/workflows/quality-engineering.yml
+++ b/.github/workflows/quality-engineering.yml
@@ -459,6 +459,12 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-nodejs
     steps:
+      - name: "Set up JDK 17"
+        uses: actions/setup-java@de1bb2b0c5634f0fc4438d7aa9944e68f9bf86cc # v3.6.0
+        with:
+          distribution: temurin
+          java-version: 17
+          overwrite-settings: false
       - name: "Trusted checkout"
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
         if: github.event.pull_request.head.repo.fork == false


### PR DESCRIPTION
Sonarcloud now requires JDK 17 + as it just deprecated JDK 11 usage.

All sonarcloud Node.js scans are failing due to this issue on B2BSuite repositories.

This PR should fix this issue.